### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-  "name": "analyticsdata",
-  "name_pretty": "Analytics Data API",
-  "product_documentation": "https://developers.google.com/analytics/",
-  "client_documentation": "https://googleapis.dev/python/analyticsdata/latest",
-  "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:187400%2B%20",
-  "release_level": "beta",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-analytics-data",
-  "distribution_name": "google-analytics-data",
-  "api_id": "analyticsdata.googleapis.com",
-  "requires_billing": true
+    "name": "analyticsdata",
+    "name_pretty": "Analytics Data API",
+    "product_documentation": "https://developers.google.com/analytics/",
+    "client_documentation": "https://googleapis.dev/python/analyticsdata/latest",
+    "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:187400%2B%20",
+    "release_level": "beta",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-analytics-data",
+    "distribution_name": "google-analytics-data",
+    "api_id": "analyticsdata.googleapis.com",
+    "requires_billing": true,
+    "default_version": "",
+    "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "distribution_name": "google-analytics-data",
     "api_id": "analyticsdata.googleapis.com",
     "requires_billing": true,
-    "default_version": "",
+    "default_version": "v1beta",
     "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs. 

https://github.com/googleapis/synthtool/pull/1201
https://github.com/googleapis/synthtool/pull/1114